### PR TITLE
Add arm64 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 **/node_modules
+image

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+image
 server/package*.json
 
 # Logs

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -14,6 +14,7 @@ RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bi
 COPY ["./", "/inference-server"]
 RUN cp /inference-server/server/configs/package.cpu.json /inference-server/server/package.json
 
+ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -22,5 +23,10 @@ WORKDIR /inference-server/server
 RUN rm -rf ./node_modules && \
     npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH && \
     npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH pm2 -g --verbose
+
+# tfjs on arm needs to be rebuilt from source
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        npm rebuild --target_platform=$TARGETOS --target_arch=$TARGETARCH @tensorflow/tfjs-node --build-from-source; \
+    fi 
 
 ENTRYPOINT ["pm2-runtime", "pm2.config.js"]

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,24 +1,26 @@
-FROM ubuntu:18.04
+FROM --platform=$TARGETPLATFORM ubuntu:20.04
 MAINTAINER Roboflow <docker@roboflow.com>
 ENV TZ=Etc/UTC
 ENV ROBOFLOW_PACKAGE="roboflow-node"
 
-RUN apt update
-RUN apt-get -y install curl net-tools build-essential python3
+RUN apt update && \
+    apt-get -y install curl net-tools build-essential python3
 
 # Install NVM and Node.js LTS
-RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n
-RUN chmod +x /usr/local/bin/n
-RUN /usr/local/bin/n lts
-
-RUN npm install pm2 -g
+RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n && \
+    chmod +x /usr/local/bin/n && \
+    /usr/local/bin/n lts
 
 COPY ["./", "/inference-server"]
 RUN cp /inference-server/server/configs/package.cpu.json /inference-server/server/package.json
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Install proper dependencies
 WORKDIR /inference-server/server
-RUN rm -rf ./node_modules
-RUN npm install
+RUN rm -rf ./node_modules && \
+    npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH && \
+    npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH pm2 -g --verbose
 
 ENTRYPOINT ["pm2-runtime", "pm2.config.js"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -26,7 +26,7 @@ RUN rm -rf ./node_modules && \
     npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH pm2 -g
 
 # tfjs on arm needs to be rebuilt from source
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
         npm rebuild --target_platform=$TARGETOS --target_arch=$TARGETARCH @tensorflow/tfjs-node --build-from-source; \
     fi 
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.5.2-cudnn8-devel-ubuntu20.04
+FROM --platform=$TARGETPLATFORM nvidia/cuda:11.5.2-cudnn8-devel-ubuntu20.04
 MAINTAINER Roboflow <docker@roboflow.com>
 ENV TZ=Etc/UTC
 ENV ROBOFLOW_PACKAGE="roboflow-node-gpu"
@@ -15,11 +15,20 @@ RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bi
 COPY ["./", "/inference-server"]
 RUN cp /inference-server/server/configs/package.gpu.json /inference-server/server/package.json
 
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
 # Install proper dependencies
 WORKDIR /inference-server/server
 RUN rm -rf ./node_modules && \
-    npm install && \
-    npm install pm2 -g
+    npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH && \
+    npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH pm2 -g
+
+# tfjs on arm needs to be rebuilt from source
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        npm rebuild --target_platform=$TARGETOS --target_arch=$TARGETARCH @tensorflow/tfjs-node --build-from-source; \
+    fi 
 
 # RUN ln -s /usr/local/cuda/bin/ptxas bin/ptxas
 # RUN chmod +x bin/ptxas

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -26,6 +26,7 @@ RUN rm -rf ./node_modules && \
     npm install --target_platform=$TARGETOS --target_arch=$TARGETARCH pm2 -g
 
 # tfjs on arm needs to be rebuilt from source
+# but we have disabled this anyway because there's no libtensorflow binary for ARM64
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
         npm rebuild --target_platform=$TARGETOS --target_arch=$TARGETARCH @tensorflow/tfjs-node --build-from-source; \
     fi 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,26 +1,25 @@
-FROM nvidia/cuda:11.4.1-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.5.2-cudnn8-devel-ubuntu20.04
 MAINTAINER Roboflow <docker@roboflow.com>
 ENV TZ=Etc/UTC
 ENV ROBOFLOW_PACKAGE="roboflow-node-gpu"
 ENV TF_FORCE_GPU_ALLOW_GROWTH=true
 
-RUN apt update
-RUN apt-get -y install curl net-tools build-essential python3
+RUN apt update && \
+    apt-get -y install curl net-tools build-essential python3
 
 # Install NVM and Node.js LTS
-RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n
-RUN chmod +x /usr/local/bin/n
-RUN /usr/local/bin/n lts
-
-RUN npm install pm2 -g
+RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n && \
+    chmod +x /usr/local/bin/n && \
+    /usr/local/bin/n lts
 
 COPY ["./", "/inference-server"]
 RUN cp /inference-server/server/configs/package.gpu.json /inference-server/server/package.json
 
 # Install proper dependencies
 WORKDIR /inference-server/server
-RUN rm -rf ./node_modules
-RUN npm install
+RUN rm -rf ./node_modules && \
+    npm install && \
+    npm install pm2 -g
 
 # RUN ln -s /usr/local/cuda/bin/ptxas bin/ptxas
 # RUN chmod +x bin/ptxas

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+# needed to build multi-platform images
+docker buildx create --name roboflow
+docker buildx use roboflow
+
 echo "🛠 : Building roboflow/inference-server:cpu"
-docker buildx build --platform linux/amd64 -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
+docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
 
-echo ""
-echo "🛠 : Building roboflow/inference-server:gpu"
-docker buildx build --platform linux/amd64 -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+# echo ""
+# echo "🛠 : Building roboflow/inference-server:gpu"
+# docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
 
-echo ""
-echo "🛠 : Building roboflow/inference-server:jetson"
-docker buildx build --platform linux/arm64 -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson
+# echo ""
+# echo "🛠 : Building roboflow/inference-server:jetson"
+# docker buildx build --platform linux/arm64 --output=image -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "robofl
 
 echo ""
 echo "🛠 : Building roboflow/inference-server:gpu"
-docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+docker buildx build --platform linux/amd64 --output=image -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
 
 echo ""
 echo "🛠 : Building roboflow/inference-server:jetson"

--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,10 @@ docker buildx use roboflow
 echo "🛠 : Building roboflow/inference-server:cpu"
 docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
 
-# echo ""
-# echo "🛠 : Building roboflow/inference-server:gpu"
-# docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+echo ""
+echo "🛠 : Building roboflow/inference-server:gpu"
+docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
 
-# echo ""
-# echo "🛠 : Building roboflow/inference-server:jetson"
-# docker buildx build --platform linux/arm64 --output=image -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson
+echo ""
+echo "🛠 : Building roboflow/inference-server:jetson"
+docker buildx build --platform linux/arm64 --output=image -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-echo "🚀 : Deploying roboflow/inference-server:cpu"
-docker push "roboflow/inference-server:cpu"
+# needed to build multi-platform images
+docker buildx create --name roboflow
+docker buildx use roboflow
 
-echo ""
-echo "🚀 : Deploying roboflow/inference-server:gpu"
-docker push "roboflow/inference-server:gpu"
+echo "🛠 : Building roboflow/inference-server:cpu"
+docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
 
-echo ""
-echo "🚀 : Deploying roboflow/inference-server:jetson"
-docker push "roboflow/inference-server:jetson"
+# echo ""
+# echo "🛠 : Building roboflow/inference-server:gpu"
+# docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+
+# echo ""
+# echo "🛠 : Building roboflow/inference-server:jetson"
+# docker buildx build --platform linux/arm64 --push -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,10 +7,10 @@ docker buildx use roboflow
 echo "🛠 : Building roboflow/inference-server:cpu"
 docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
 
-# echo ""
-# echo "🛠 : Building roboflow/inference-server:gpu"
-# docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+echo ""
+echo "🛠 : Building roboflow/inference-server:gpu"
+docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
 
-# echo ""
-# echo "🛠 : Building roboflow/inference-server:jetson"
-# docker buildx build --platform linux/arm64 --push -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson
+echo ""
+echo "🛠 : Building roboflow/inference-server:jetson"
+docker buildx build --platform linux/arm64 --push -t "roboflow/inference-server:jetson" -f- . < Dockerfile.jetson

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/infer
 
 echo ""
 echo "🛠 : Building roboflow/inference-server:gpu"
-docker buildx build --platform linux/amd64,linux/arm64 --push -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
+docker buildx build --platform linux/amd64 --push -t "roboflow/inference-server:gpu" -f- . < Dockerfile.gpu
 
 echo ""
 echo "🛠 : Building roboflow/inference-server:jetson"

--- a/server/configs/package.cpu.json
+++ b/server/configs/package.cpu.json
@@ -1,7 +1,7 @@
 {
   "name": "roboflow-inference-server-cpu",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Roboflow Infer on-prem server.",
   "main": "index.js",
   "scripts": {
@@ -39,6 +39,6 @@
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
     "lodash": "^4.17.21",
-    "roboflow-node": "^0.2.21"
+    "roboflow-node": "^0.2.22"
   }
 }

--- a/server/configs/package.gpu.json
+++ b/server/configs/package.gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "roboflow-inference-server-gpu",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Roboflow Infer on-prem server.",
   "main": "index.js",
   "scripts": {
@@ -39,6 +39,6 @@
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
     "lodash": "^4.17.21",
-    "roboflow-node-gpu": "^0.2.21"
+    "roboflow-node-gpu": "^0.2.22"
   }
 }

--- a/server/configs/package.jetson.json
+++ b/server/configs/package.jetson.json
@@ -1,7 +1,7 @@
 {
   "name": "roboflow-inference-server-jetson",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Roboflow Infer on-prem server.",
   "main": "index.js",
   "scripts": {
@@ -39,6 +39,6 @@
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
     "lodash": "^4.17.21",
-    "roboflow-jetson": "^0.2.21"
+    "roboflow-jetson": "^0.2.22"
   }
 }


### PR DESCRIPTION
This pulls in the updates from `roboflow.js` which enable `arm64` (cpu) builds for Mac (can't be used with Docker; I'll update the installation instructions for local installs), AWS Graviton & Raspberry Pi.