### PR TITLE
adding image prop to results

### DIFF
--- a/server/configs/package.cpu.json
+++ b/server/configs/package.cpu.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
+    "image-size": "^1.0.2",
     "lodash": "^4.17.21",
     "roboflow-node": "^0.2.22"
   }

--- a/server/configs/package.gpu.json
+++ b/server/configs/package.gpu.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
+    "image-size": "^1.0.2",
     "lodash": "^4.17.21",
     "roboflow-node-gpu": "^0.2.22"
   }

--- a/server/configs/package.jetson.json
+++ b/server/configs/package.jetson.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
+    "image-size": "^1.0.2",
     "lodash": "^4.17.21",
     "roboflow-jetson": "^0.2.22"
   }

--- a/server/index.js
+++ b/server/index.js
@@ -245,7 +245,6 @@ var infer = function(req, res) {
                 if ("image" in result === false)
                     result["image"] = {'width': width, 'height': height}
        
-                console.log(`*** result ${JSON.stringify(result)}`)
                 res.json(result);
             }).catch(error => {
                 res.json({

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,8 @@ const async = require("async");
 const _ = require("lodash");
 const fs = require("fs");
 
+const sizeOf = require('image-size')
+
 const package_info = JSON.parse(fs.readFileSync(__dirname + "/package.json"));
 
 //var staging = true;
@@ -146,6 +148,12 @@ var infer = function(req, res) {
         var start = Date.now();
 
         var buffer = Buffer.from(req.body, "base64");
+
+        // use sizeOf on buffer to get image width and height
+        var dimensions = sizeOf(buffer);
+        var width = dimensions.width 
+        var height = dimensions.height
+
         var arr = new Uint8Array(buffer);
 
         var tensor;
@@ -232,7 +240,12 @@ var infer = function(req, res) {
             });
         } else {
             detect(req, res, start, tensor)
-            .then(result => {
+            .then(result => {  
+                // apply width and height to response object       
+                if ("image" in result === false)
+                    result["image"] = {'width': width, 'height': height}
+       
+                console.log(`*** result ${JSON.stringify(result)}`)
                 res.json(result);
             }).catch(error => {
                 res.json({

--- a/server/index.js
+++ b/server/index.js
@@ -231,11 +231,13 @@ var infer = function(req, res) {
                 });
             }).then((result) => {
                 res.json({
-                    predictions: combinedResult
+                    predictions: combinedResult,
+                    image: {'width': width, 'height': height}
                 });
             }).catch(error => {
                 res.json({
-                    predictions: combinedResult
+                    predictions: combinedResult,
+                    image: {'width': width, 'height': height}
                 });
             });
         } else {


### PR DESCRIPTION
# Description

The pip package logic always expects an `image` property to be provided by the inference server. This PR adds logic to ensure that an `image` property gets appended to `results` using the `image-size` package if no `image` property present before sending the `res`.

New dependency:
- `image-size`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Dev'd locally in my own `inference-server` env and built using `docker buildx build --platform linux/amd64,linux/arm64 --output=image -t "roboflow/inference-server:cpu" -f- . < Dockerfile.cpu
`

## Docs

-   [ ] Docs updated? What were the changes: No changes required.
