### PR TITLE
Deprecate this Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# ⚠️ DEPRECATION WARNING
+
+The code in this repo is deprecated. It contains the code for the old Node.js based Roboflow Inference server powered by
+[roboflow.js](https://docs.roboflow.com/deploy/web-browser) and TFjs-node.
+
+The [new Roboflow Inference Server](https://github.com/roboflow/inference) is
+fully open-source, faster, supports more models, works on more devices,
+has more features,  is under active development, and is better in every way.
+
+You should [use that](https://github.com/roboflow/inference) instead.
+
+<details close>
+<summary>Old Readme Content</summary>
 # Roboflow Edge Inference Server
 
 The Roboflow Edge Inference Server is an on-device implementation of our
@@ -100,3 +113,4 @@ computer vision into your applications all the way from annotation to deployment
 
 [Get started](https://app.roboflow.com) with a free account and you'll have
 a working model tailored to your specific use-case in an afternoon.
+</details>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The code in this repo is deprecated. It contains the code for the old Node.js ba
 [roboflow.js](https://docs.roboflow.com/deploy/web-browser) and TFjs-node.
 
 The [new Roboflow Inference Server](https://github.com/roboflow/inference) is
-fully open-source, faster, supports more models, works on more devices,
-has more features,  is under active development, and is better in every way.
+open-source, faster, supports more models, works on more devices,
+has more features, is under active development, and is better in every way.
 
 You should [use that](https://github.com/roboflow/inference) instead.
 


### PR DESCRIPTION
# Description

Deprecates this repo in favor of [the new Roboflow Inference Server and `inference` package](https://github.com/roboflow/inference).

## Type of change

-   [x] Documentation Change

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not needed, copy change.

## Any specific deployment considerations

No deploy needed, copy change.

## Docs

- This is the documentation update.
